### PR TITLE
Revamp UI with liquid glass style and colorful background

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -276,20 +276,6 @@ body {
    LANGUAGE SELECTOR
    ======================================== */
 
-.language-selector-wrapper {
-  position: fixed;
-  top: 1.5rem;
-  right: 1.5rem;
-  z-index: 20;
-}
-
-@media (min-width: 640px) {
-  .language-selector-wrapper {
-    top: 2rem;
-    right: 2rem;
-  }
-}
-
 .language-selector {
   position: relative;
   display: inline-block;

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,13 +1,13 @@
 @import "tailwindcss";
 
 :root {
-  --bg-base: #0f172a;
-  --bg-surface: rgba(226, 232, 240, 0.08);
-  --bg-card: rgba(30, 41, 59, 0.4);
+  --bg-base: #1a1f35;
+  --bg-surface: rgba(226, 232, 240, 0.1);
+  --bg-card: rgba(255, 255, 255, 0.08);
   --text-primary: #f1f5f9;
   --text-secondary: #cbd5e1;
-  --border-default: rgba(148, 163, 184, 0.1);
-  --border-hover: rgba(148, 163, 184, 0.3);
+  --border-default: rgba(255, 255, 255, 0.2);
+  --border-hover: rgba(255, 255, 255, 0.3);
   --focus-ring: rgba(99, 102, 241, 0.5);
   --accent: #6366f1;
   --accent-light: #818cf8;
@@ -56,12 +56,12 @@ body {
   z-index: 0;
   background: linear-gradient(
     135deg,
-    #0f172a 0%,
-    #7c3aed 20%,
-    #2563eb 40%,
-    #06b6d4 60%,
-    #ec4899 80%,
-    #0f172a 100%
+    #1a1f35 0%,
+    #a78bfa 20%,
+    #60a5fa 40%,
+    #34d399 60%,
+    #f472b6 80%,
+    #1a1f35 100%
   );
   background-size: 400% 400%;
   animation: gradientShift 20s ease infinite, colorCycle 45s ease-in-out infinite;
@@ -105,7 +105,7 @@ body {
   background: radial-gradient(
     ellipse at center,
     transparent 0%,
-    rgba(0, 0, 0, 0.3) 100%
+    rgba(0, 0, 0, 0.15) 100%
   );
   pointer-events: none;
 }
@@ -116,15 +116,15 @@ body {
 
 .coming-soon-card {
   position: relative;
-  background: rgba(30, 41, 59, 0.25);
-  backdrop-filter: blur(40px);
-  -webkit-backdrop-filter: blur(40px);
-  border: 1px solid rgba(148, 163, 184, 0.15);
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(50px);
+  -webkit-backdrop-filter: blur(50px);
+  border: 1px solid rgba(255, 255, 255, 0.25);
   border-radius: 2.5rem;
   text-align: center;
   box-shadow:
-    0 20px 40px -10px rgba(0, 0, 0, 0.2),
-    0 0 0 1px rgba(255, 255, 255, 0.08) inset;
+    0 20px 60px -10px rgba(0, 0, 0, 0.15),
+    0 0 0 1px rgba(255, 255, 255, 0.2) inset;
   transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
   /* Rectangle: wider than tall for hero feel */
   width: clamp(300px, min(85vw, 85vh), 580px);
@@ -138,11 +138,11 @@ body {
 }
 
 .coming-soon-card:hover {
-  background: rgba(30, 41, 59, 0.35);
-  border-color: rgba(148, 163, 184, 0.25);
+  background: rgba(255, 255, 255, 0.15);
+  border-color: rgba(255, 255, 255, 0.35);
   box-shadow:
-    0 20px 40px -10px rgba(99, 102, 241, 0.15),
-    0 0 0 1px rgba(148, 163, 184, 0.15) inset;
+    0 20px 60px -10px rgba(99, 102, 241, 0.2),
+    0 0 0 1px rgba(255, 255, 255, 0.3) inset;
 }
 
 @media (max-width: 768px) {
@@ -302,9 +302,9 @@ body {
 
 .language-selector select {
   appearance: none;
-  background: rgba(30, 41, 59, 0.5);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
+  background: rgba(255, 255, 255, 0.12);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
   border: 1px solid var(--border-default);
   border-radius: 0.75rem;
   padding: 0.5rem 2.5rem 0.5rem 1rem;
@@ -314,12 +314,12 @@ body {
   cursor: pointer;
   transition: all 0.2s ease-in-out;
   min-width: 120px;
-  background-color: rgba(30, 41, 59, 0.5);
 }
 
 .language-selector select:hover {
   border-color: var(--accent);
-  background: rgba(30, 41, 59, 0.6);
+  background: rgba(255, 255, 255, 0.18);
+  box-shadow: 0 0 20px rgba(99, 102, 241, 0.2);
 }
 
 .language-selector select:focus {

--- a/app/globals.css
+++ b/app/globals.css
@@ -276,6 +276,20 @@ body {
    LANGUAGE SELECTOR
    ======================================== */
 
+.language-selector-wrapper {
+  position: fixed;
+  top: 1.5rem;
+  right: 1.5rem;
+  z-index: 20;
+}
+
+@media (min-width: 640px) {
+  .language-selector-wrapper {
+    top: 2rem;
+    right: 2rem;
+  }
+}
+
 .language-selector {
   position: relative;
   display: inline-block;

--- a/app/globals.css
+++ b/app/globals.css
@@ -57,13 +57,14 @@ body {
   background: linear-gradient(
     135deg,
     #0f172a 0%,
-    #1e293b 25%,
-    #334155 50%,
-    #1e40af 75%,
+    #7c3aed 20%,
+    #2563eb 40%,
+    #06b6d4 60%,
+    #ec4899 80%,
     #0f172a 100%
   );
   background-size: 400% 400%;
-  animation: gradientShift 20s ease infinite;
+  animation: gradientShift 20s ease infinite, colorCycle 45s ease-in-out infinite;
 }
 
 @keyframes gradientShift {
@@ -75,6 +76,24 @@ body {
   }
   100% {
     background-position: 0% 50%;
+  }
+}
+
+@keyframes colorCycle {
+  0% {
+    filter: hue-rotate(0deg) saturate(1);
+  }
+  25% {
+    filter: hue-rotate(60deg) saturate(1.2);
+  }
+  50% {
+    filter: hue-rotate(120deg) saturate(1.1);
+  }
+  75% {
+    filter: hue-rotate(240deg) saturate(1.2);
+  }
+  100% {
+    filter: hue-rotate(360deg) saturate(1);
   }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -178,17 +178,13 @@ body {
   font-weight: 700;
   letter-spacing: -0.02em;
   line-height: 1.2;
-  color: var(--text-primary);
+  color: #ffffff;
   margin-bottom: 1.25rem;
-  background: linear-gradient(
-    135deg,
-    var(--accent-light) 20%,
-    var(--accent) 80%
-  );
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-  opacity: 0.95;
+  text-shadow:
+    0 0 30px rgba(255, 255, 255, 0.3),
+    0 0 60px rgba(99, 102, 241, 0.2),
+    0 2px 10px rgba(0, 0, 0, 0.2);
+  opacity: 1;
 }
 
 @media (max-width: 768px) {

--- a/app/globals.css
+++ b/app/globals.css
@@ -116,15 +116,16 @@ body {
 
 .coming-soon-card {
   position: relative;
-  background: rgba(255, 255, 255, 0.1);
-  backdrop-filter: blur(50px);
-  -webkit-backdrop-filter: blur(50px);
-  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: rgba(255, 255, 255, 0.18);
+  backdrop-filter: blur(60px);
+  -webkit-backdrop-filter: blur(60px);
+  border: 1.5px solid rgba(255, 255, 255, 0.35);
   border-radius: 2.5rem;
   text-align: center;
   box-shadow:
-    0 20px 60px -10px rgba(0, 0, 0, 0.15),
-    0 0 0 1px rgba(255, 255, 255, 0.2) inset;
+    0 25px 80px -15px rgba(0, 0, 0, 0.2),
+    0 0 0 1px rgba(255, 255, 255, 0.3) inset,
+    0 0 40px rgba(99, 102, 241, 0.1);
   transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
   /* Rectangle: wider than tall for hero feel */
   width: clamp(300px, min(85vw, 85vh), 580px);
@@ -138,11 +139,12 @@ body {
 }
 
 .coming-soon-card:hover {
-  background: rgba(255, 255, 255, 0.15);
-  border-color: rgba(255, 255, 255, 0.35);
+  background: rgba(255, 255, 255, 0.22);
+  border-color: rgba(255, 255, 255, 0.45);
   box-shadow:
-    0 20px 60px -10px rgba(99, 102, 241, 0.2),
-    0 0 0 1px rgba(255, 255, 255, 0.3) inset;
+    0 30px 100px -15px rgba(99, 102, 241, 0.25),
+    0 0 0 1.5px rgba(255, 255, 255, 0.4) inset,
+    0 0 60px rgba(99, 102, 241, 0.15);
 }
 
 @media (max-width: 768px) {

--- a/app/globals.css
+++ b/app/globals.css
@@ -64,7 +64,9 @@ body {
     #1a1f35 100%
   );
   background-size: 400% 400%;
-  animation: gradientShift 20s ease infinite, colorCycle 45s ease-in-out infinite;
+  animation:
+    gradientShift 20s ease infinite,
+    colorCycle 45s ease-in-out infinite;
 }
 
 @keyframes gradientShift {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,7 +17,7 @@ export default function Home() {
       <div className="animated-gradient" aria-hidden="true" />
 
       {/* Language selector - top right */}
-      <div className="fixed top-6 right-6 z-20 sm:top-8 sm:right-8">
+      <div className="language-selector-wrapper">
         <div className="language-selector">
           <select
             id="language-select"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,7 +17,7 @@ export default function Home() {
       <div className="animated-gradient" aria-hidden="true" />
 
       {/* Language selector - top right */}
-      <div className="language-selector-wrapper">
+      <div className="fixed top-6 right-6 z-20 sm:top-8 sm:right-8">
         <div className="language-selector">
           <select
             id="language-select"


### PR DESCRIPTION
## **User description**
### Summary
This PR overhauls the visual design with a liquid glass aesthetic, a vibrant animated gradient background, and improved readability for the "Coming Soon" card and language selector.

### Problem
The original UI had a dark, bland gradient background and a card design that lacked visual clarity. The "Coming Soon" title used a purple gradient text that was hard to read, and the overall glassmorphism effect was too subtle and dark.

### Solution
Replaced the muted dark color palette with lighter, more translucent glass-style surfaces and a vivid multi-color animated gradient background. The "Coming Soon" title was switched to solid white with a soft glow text-shadow for better visibility.

### Key Changes
- **Animated background**: Updated gradient stops to include vibrant colors (`#a78bfa`, `#60a5fa`, `#34d399`, `#f472b6`) and added a `colorCycle` keyframe animation using `hue-rotate` and `saturate` filters for dynamic color shifting over time
- **Lighter overlay**: Reduced the radial gradient overlay opacity from `0.3` to `0.15` for a less heavy feel
- **Liquid glass card**: Increased backdrop blur from `40px` to `60px`, switched card background to `rgba(255,255,255,0.18)`, and enhanced borders and box shadows with stronger white highlights and a subtle indigo glow
- **"Coming Soon" title**: Removed the purple gradient clip-text effect; replaced with plain white (`#ffffff`) and a layered `text-shadow` for a glowing, readable appearance
- **Language selector**: Updated to use a lighter frosted-glass background (`rgba(255,255,255,0.12)`) with increased blur and an indigo glow on hover
- **CSS variables**: Adjusted `--bg-base`, `--bg-card`, `--border-default`, and `--border-hover` to use lighter, more translucent white-based values

---

<a href="https://builder.io/app/projects/c4d76e15fe094f438ed3/mage-lever-saacc78b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://c4d76e15fe094f438ed3-mage-lever-saacc78b.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=c4d76e15fe094f438ed3&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 60`

You can tag me at @builderio for anything you want me to fix or change

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c4d76e15fe094f438ed3</projectId>-->
<!--<branchName>mage-lever-saacc78b</branchName>-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the global UI with a vibrant animated background, glassmorphic cards, and clearer typography for better readability and polish. Also updates the language selector styling for better contrast and hover feedback.

- **UI Improvements**
  - Updated theme variables for brighter dark mode and higher-contrast borders.
  - Added multi-color animated gradient with hue cycling; softened overlay for depth.
  - Enhanced “Coming Soon” card with stronger glass effect, increased blur, refined borders/shadows, and richer hover glow.
  - Switched heading to solid white with a soft glow for improved legibility.
  - Restyled language selector with translucent white background, more blur, and subtle hover shadow.

<sup>Written for commit 0d7dd7a6d4f7e5f21d2a0c50314c413443315cd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LCSOGthb/Games/pull/60?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Refresh the Coming Soon screen with a brighter glass-style look**

### What Changed
- Replaced the dark background and card styling with a lighter liquid-glass design and a more vibrant animated gradient
- Made the "Coming Soon" heading plain white with a glow so it is easier to read
- Updated the language selector to match the new frosted-glass style and feel more visible on hover

### Impact
`✅ Clearer Coming Soon headline`
`✅ Brighter landing page appearance`
`✅ Easier-to-spot language selector`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a visual theme refresh of `app/globals.css`, shifting the background palette from muted dark blues to a vibrant multi-color gradient (purple → blue → green → pink) and adding a new `colorCycle` keyframe animation that continuously rotates the hue of the background element across the full 360° spectrum over 45 seconds.

- The `.animated-gradient` element now runs two parallel animations — the existing `gradientShift` and the new `colorCycle` (using `filter: hue-rotate()`) — to create a dynamic, colour-cycling background effect.
- `.coming-soon-card` glass effect is intensified (blur increased from 40 px to 60 px, higher background opacity, stronger borders and shadow spreads).
- `.coming-soon-title` drops the `-webkit-background-clip: text` gradient approach in favour of solid white with `text-shadow`, which is more broadly compatible.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all changes are purely visual CSS with no functional regressions. The main thing worth revisiting before shipping is motion accessibility.

The change is entirely cosmetic — no logic, no data, no API surface touched. The one gap worth addressing is that neither the new colorCycle animation nor the existing gradientShift are guarded by prefers-reduced-motion, which matters for users with vestibular sensitivity. Everything else is straightforward colour and shadow value tuning.

app/globals.css — specifically the animation declarations and the absence of a reduced-motion media query.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/globals.css | Visual theme refresh: brighter gradient palette, a new continuous hue-rotation animation (colorCycle), more opaque glassmorphism card, and simplified title text rendering. No prefers-reduced-motion guard covers the new or existing animations. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[".animated-gradient (fixed, z-index:0)"] -->|"animation: gradientShift 20s"| B["Background position shift\n(0% → 100% → 0%)"]
    A -->|"animation: colorCycle 45s NEW"| C["filter: hue-rotate(0→360deg)\nsaturate(1→1.2→1)"]
    A -->|"::after pseudo-element"| D["Radial gradient overlay\n(rgba(0,0,0,0.15))"]
    B --> E["Combined visual effect\non background layer"]
    C --> E
    D --> E
    E --> F[".coming-soon-card\nbackdrop-filter: blur(60px)"]
    F --> G[".coming-soon-title\nwhite + text-shadow"]
    F --> H[".language-selector select\nbackdrop-filter: blur(20px)"]
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapp%2Fglobals.css%3A82-98%0AThe%20two%20background%20animations%20%28%60gradientShift%60%20and%20the%20new%20%60colorCycle%60%29%20run%20indefinitely%20with%20no%20reduced-motion%20guard.%20The%20%60colorCycle%60%20animation%20continuously%20rotates%20the%20hue%20across%20the%20full%20360%C2%B0%20spectrum%2C%20which%20can%20be%20disorienting%20or%20physically%20uncomfortable%20for%20users%20with%20vestibular%20disorders%20%E2%80%94%20and%20the%20%60prefers-reduced-motion%3A%20reduce%60%20media%20query%20is%20absent%20from%20the%20entire%20file.%20Wrapping%20the%20animations%20so%20they%20pause%20for%20users%20who%20have%20requested%20reduced%20motion%20follows%20WCAG%202.3.3%20and%20is%20a%20simple%20addition.%0A%0A%60%60%60suggestion%0A%40keyframes%20colorCycle%20%7B%0A%20%200%25%20%7B%0A%20%20%20%20filter%3A%20hue-rotate%280deg%29%20saturate%281%29%3B%0A%20%20%7D%0A%20%2025%25%20%7B%0A%20%20%20%20filter%3A%20hue-rotate%2860deg%29%20saturate%281.2%29%3B%0A%20%20%7D%0A%20%2050%25%20%7B%0A%20%20%20%20filter%3A%20hue-rotate%28120deg%29%20saturate%281.1%29%3B%0A%20%20%7D%0A%20%2075%25%20%7B%0A%20%20%20%20filter%3A%20hue-rotate%28240deg%29%20saturate%281.2%29%3B%0A%20%20%7D%0A%20%20100%25%20%7B%0A%20%20%20%20filter%3A%20hue-rotate%28360deg%29%20saturate%281%29%3B%0A%20%20%7D%0A%7D%0A%0A%40media%20%28prefers-reduced-motion%3A%20reduce%29%20%7B%0A%20%20.animated-gradient%20%7B%0A%20%20%20%20animation%3A%20none%3B%0A%20%20%7D%0A%7D%0A%60%60%60%0A%0A&pr=60&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lcsogthb%2Fgames%22%20on%20the%20existing%20branch%20%22ai_main_6415658896f649fbb315%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ai_main_6415658896f649fbb315%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapp%2Fglobals.css%3A82-98%0AThe%20two%20background%20animations%20%28%60gradientShift%60%20and%20the%20new%20%60colorCycle%60%29%20run%20indefinitely%20with%20no%20reduced-motion%20guard.%20The%20%60colorCycle%60%20animation%20continuously%20rotates%20the%20hue%20across%20the%20full%20360%C2%B0%20spectrum%2C%20which%20can%20be%20disorienting%20or%20physically%20uncomfortable%20for%20users%20with%20vestibular%20disorders%20%E2%80%94%20and%20the%20%60prefers-reduced-motion%3A%20reduce%60%20media%20query%20is%20absent%20from%20the%20entire%20file.%20Wrapping%20the%20animations%20so%20they%20pause%20for%20users%20who%20have%20requested%20reduced%20motion%20follows%20WCAG%202.3.3%20and%20is%20a%20simple%20addition.%0A%0A%60%60%60suggestion%0A%40keyframes%20colorCycle%20%7B%0A%20%200%25%20%7B%0A%20%20%20%20filter%3A%20hue-rotate%280deg%29%20saturate%281%29%3B%0A%20%20%7D%0A%20%2025%25%20%7B%0A%20%20%20%20filter%3A%20hue-rotate%2860deg%29%20saturate%281.2%29%3B%0A%20%20%7D%0A%20%2050%25%20%7B%0A%20%20%20%20filter%3A%20hue-rotate%28120deg%29%20saturate%281.1%29%3B%0A%20%20%7D%0A%20%2075%25%20%7B%0A%20%20%20%20filter%3A%20hue-rotate%28240deg%29%20saturate%281.2%29%3B%0A%20%20%7D%0A%20%20100%25%20%7B%0A%20%20%20%20filter%3A%20hue-rotate%28360deg%29%20saturate%281%29%3B%0A%20%20%7D%0A%7D%0A%0A%40media%20%28prefers-reduced-motion%3A%20reduce%29%20%7B%0A%20%20.animated-gradient%20%7B%0A%20%20%20%20animation%3A%20none%3B%0A%20%20%7D%0A%7D%0A%60%60%60%0A%0A&repo=lcsogthb%2Fgames&pr=60&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapp%2Fglobals.css%3A82-98%0AThe%20two%20background%20animations%20%28%60gradientShift%60%20and%20the%20new%20%60colorCycle%60%29%20run%20indefinitely%20with%20no%20reduced-motion%20guard.%20The%20%60colorCycle%60%20animation%20continuously%20rotates%20the%20hue%20across%20the%20full%20360%C2%B0%20spectrum%2C%20which%20can%20be%20disorienting%20or%20physically%20uncomfortable%20for%20users%20with%20vestibular%20disorders%20%E2%80%94%20and%20the%20%60prefers-reduced-motion%3A%20reduce%60%20media%20query%20is%20absent%20from%20the%20entire%20file.%20Wrapping%20the%20animations%20so%20they%20pause%20for%20users%20who%20have%20requested%20reduced%20motion%20follows%20WCAG%202.3.3%20and%20is%20a%20simple%20addition.%0A%0A%60%60%60suggestion%0A%40keyframes%20colorCycle%20%7B%0A%20%200%25%20%7B%0A%20%20%20%20filter%3A%20hue-rotate%280deg%29%20saturate%281%29%3B%0A%20%20%7D%0A%20%2025%25%20%7B%0A%20%20%20%20filter%3A%20hue-rotate%2860deg%29%20saturate%281.2%29%3B%0A%20%20%7D%0A%20%2050%25%20%7B%0A%20%20%20%20filter%3A%20hue-rotate%28120deg%29%20saturate%281.1%29%3B%0A%20%20%7D%0A%20%2075%25%20%7B%0A%20%20%20%20filter%3A%20hue-rotate%28240deg%29%20saturate%281.2%29%3B%0A%20%20%7D%0A%20%20100%25%20%7B%0A%20%20%20%20filter%3A%20hue-rotate%28360deg%29%20saturate%281%29%3B%0A%20%20%7D%0A%7D%0A%0A%40media%20%28prefers-reduced-motion%3A%20reduce%29%20%7B%0A%20%20.animated-gradient%20%7B%0A%20%20%20%20animation%3A%20none%3B%0A%20%20%7D%0A%7D%0A%60%60%60%0A%0A&repo=lcsogthb%2Fgames&pr=60&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lcsogthb%2Fgames%22%20on%20the%20existing%20branch%20%22ai_main_6415658896f649fbb315%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ai_main_6415658896f649fbb315%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapp%2Fglobals.css%3A82-98%0AThe%20two%20background%20animations%20%28%60gradientShift%60%20and%20the%20new%20%60colorCycle%60%29%20run%20indefinitely%20with%20no%20reduced-motion%20guard.%20The%20%60colorCycle%60%20animation%20continuously%20rotates%20the%20hue%20across%20the%20full%20360%C2%B0%20spectrum%2C%20which%20can%20be%20disorienting%20or%20physically%20uncomfortable%20for%20users%20with%20vestibular%20disorders%20%E2%80%94%20and%20the%20%60prefers-reduced-motion%3A%20reduce%60%20media%20query%20is%20absent%20from%20the%20entire%20file.%20Wrapping%20the%20animations%20so%20they%20pause%20for%20users%20who%20have%20requested%20reduced%20motion%20follows%20WCAG%202.3.3%20and%20is%20a%20simple%20addition.%0A%0A%60%60%60suggestion%0A%40keyframes%20colorCycle%20%7B%0A%20%200%25%20%7B%0A%20%20%20%20filter%3A%20hue-rotate%280deg%29%20saturate%281%29%3B%0A%20%20%7D%0A%20%2025%25%20%7B%0A%20%20%20%20filter%3A%20hue-rotate%2860deg%29%20saturate%281.2%29%3B%0A%20%20%7D%0A%20%2050%25%20%7B%0A%20%20%20%20filter%3A%20hue-rotate%28120deg%29%20saturate%281.1%29%3B%0A%20%20%7D%0A%20%2075%25%20%7B%0A%20%20%20%20filter%3A%20hue-rotate%28240deg%29%20saturate%281.2%29%3B%0A%20%20%7D%0A%20%20100%25%20%7B%0A%20%20%20%20filter%3A%20hue-rotate%28360deg%29%20saturate%281%29%3B%0A%20%20%7D%0A%7D%0A%0A%40media%20%28prefers-reduced-motion%3A%20reduce%29%20%7B%0A%20%20.animated-gradient%20%7B%0A%20%20%20%20animation%3A%20none%3B%0A%20%20%7D%0A%7D%0A%60%60%60%0A%0A&repo=lcsogthb%2Fgames"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=3"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["style: format code with Autopep8, Black,..."](https://github.com/lcsogthb/games/commit/e7e4308fd5df8fea0562adcb286566018dba7a50) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37268584)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->